### PR TITLE
Handles removed `--export` flag

### DIFF
--- a/scripts/copy-cloudnative-resources-to-namespace.sh
+++ b/scripts/copy-cloudnative-resources-to-namespace.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
+
 print_usage() {
     echo "Missing required arguments"
     echo "Usage: $0 {KIND} {TO_NAMESPACE} [{FROM_NAMESPACE}]"
@@ -42,6 +44,6 @@ while read -r name; do
   else
     echo "*** Copying ${KIND}/${name} from ${FROM_NAMESPACE} namespace to ${TO_NAMESPACE} namespace"
 
-    kubectl get "${KIND}/${name}" -n "${FROM_NAMESPACE}" -o yaml --export | kubectl apply -n "${TO_NAMESPACE}" -f -
+    "${SCRIPT_DIR}/kubectl-export.sh" "${KIND}" "${name}" "${FROM_NAMESPACE}" | kubectl apply -n "${TO_NAMESPACE}" -f -
   fi
 done

--- a/scripts/kubectl-export.sh
+++ b/scripts/kubectl-export.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+KIND="$1"
+RESOURCE="$2"
+NAMESPACE="$3"
+
+if [[ -n "${NAMESPACE}" ]]; then
+  NAMESPACE="-n ${NAMESPACE}"
+fi
+
+if [[ -z "$TMP_DIR" ]]; then
+  TMP_DIR="${PWD}/.tmp"
+fi
+mkdir -p "${TMP_DIR}/bin" &> /dev/null
+
+if ! command -v jq &> /dev/null; then
+  curl -sLo "${TMP_DIR}/bin/jq" https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
+  export PATH="$PATH:${TMP_DIR}/bin"
+fi
+
+kubectl get "${KIND}/${RESOURCE}" ${NAMESPACE} -o json | jq 'del(.metadata.uid) | del(.metadata.selfLink) | del(.metadata.resourceVersion) | del(.metadata.namespace) | del(.metadata.creationTimestamp)'


### PR DESCRIPTION
- Adds kubectl-export.sh that uses jq to remove unnecessary metadata values
- Updates copy-cloudnative-resources-to-namespace.sh and setup-namespace-pull-secrets.sh to use kubectl-export.sh